### PR TITLE
Minor bug fix and warning suppression.

### DIFF
--- a/CGridListCtrlEx/CGridListCtrlGroups.cpp
+++ b/CGridListCtrlEx/CGridListCtrlGroups.cpp
@@ -1232,12 +1232,13 @@ BOOL CGridListCtrlGroups::OnGetEmptyMarkup(NMHDR* pNMHDR, LRESULT* pResult)
 //! @param pResult Not used
 //! @return Is final message handler (Return FALSE to continue routing the message)
 //------------------------------------------------------------------------
-BOOL CGridListCtrlGroups::OnGroupTaskClick(NMHDR* pNMHDR, LRESULT* /* pResult */)
+BOOL CGridListCtrlGroups::OnGroupTaskClick(NMHDR* pNMHDR, LRESULT* pResult)
 {
 #if _WIN32_WINNT >= 0x0600
 	NMLVLINK* pLinkInfo = reinterpret_cast<NMLVLINK*>(pNMHDR);
 	int nGroupId = pLinkInfo->iSubItem;
-	(nGroupId);	// Avoid unreferenced variable warning
+	(nGroupId);			// Avoid unreferenced variable warning
+	(pResult);			// Avoid unreferenced variable warning
 #else
 	(pNMHDR);			// Avoid unreferenced variable warning
 	(pResult);			// Avoid unreferenced variable warning

--- a/CGridListCtrlEx/CGridListCtrlGroups.cpp
+++ b/CGridListCtrlEx/CGridListCtrlGroups.cpp
@@ -1232,7 +1232,7 @@ BOOL CGridListCtrlGroups::OnGetEmptyMarkup(NMHDR* pNMHDR, LRESULT* pResult)
 //! @param pResult Not used
 //! @return Is final message handler (Return FALSE to continue routing the message)
 //------------------------------------------------------------------------
-BOOL CGridListCtrlGroups::OnGroupTaskClick(NMHDR* pNMHDR, LRESULT* pResult)
+BOOL CGridListCtrlGroups::OnGroupTaskClick(NMHDR* pNMHDR, LRESULT* /* pResult */)
 {
 #if _WIN32_WINNT >= 0x0600
 	NMLVLINK* pLinkInfo = reinterpret_cast<NMLVLINK*>(pNMHDR);
@@ -1432,7 +1432,7 @@ namespace
 		}
 	};
 
-	int group_info_cmp(const void *a, const void *b)
+	int __cdecl group_info_cmp(const void *a, const void *b)
 	{
 		const struct group_info *ia = reinterpret_cast<const struct group_info*>(a);
 		const struct group_info *ib = reinterpret_cast<const struct group_info*>(b);


### PR DESCRIPTION
The qsort() function requires that its predicate (in this case,
the group_info_cmp() function) use the __cdecl calling
convention. When a different default calling convention
is set globally for a project (e.g., /Gz or /Gv), this results
in a compiler failure, since the predicate has the wrong
calling convention. Adding an explicit annotation of
the __cdecl calling convention fixes this problem
with no side effects.

Elsewhere, an unused parameter was commented out
in the definition to avoid a warning.