### PR TITLE
Do not enforce min/max widths for hidden columns

### DIFF
--- a/CGridListCtrlEx/CGridListCtrlEx.cpp
+++ b/CGridListCtrlEx/CGridListCtrlEx.cpp
@@ -3379,7 +3379,8 @@ BOOL CGridListCtrlEx::OnHeaderEndResize(UINT, NMHDR* pNMHDR, LRESULT* pResult)
 //------------------------------------------------------------------------
 BOOL CGridListCtrlEx::OnHeaderItemChanging(UINT, NMHDR* pNMHDR, LRESULT* pResult)
 {
-	// Check if the column have a minimum width
+	// If the column has traits associated with it and the column is visible,
+	// enforce any minimum and/or maximum widths defined by the traits.
 	NMHEADER* pNMH = reinterpret_cast<NMHEADER*>(pNMHDR);
 
 	if (pNMH->pitem->mask & HDI_WIDTH)
@@ -3387,6 +3388,8 @@ BOOL CGridListCtrlEx::OnHeaderItemChanging(UINT, NMHDR* pNMHDR, LRESULT* pResult
 		int nCol = pNMH->iItem;
 		CGridColumnTrait* pTrait = GetColumnTrait(nCol);
 		if (pTrait == NULL)
+			return FALSE;
+		if (!pTrait->GetColumnState().m_Visible)
 			return FALSE;
 
 		if (pTrait->GetColumnState().m_MinWidth >= 0)

--- a/CGridListCtrlEx/CGridListCtrlEx.cpp
+++ b/CGridListCtrlEx/CGridListCtrlEx.cpp
@@ -1594,8 +1594,8 @@ BOOL CGridListCtrlEx::ShowColumn(int nCol, bool bShow)
 	{
 		// Backup the column width
 		const int orgWidth = GetColumnWidth(nCol);
-		VERIFY(SetColumnWidth(nCol, 0));
 		columnState.m_Visible = false;
+		VERIFY(SetColumnWidth(nCol, 0));
 		columnState.m_OrgWidth = orgWidth;
 	}
 


### PR DESCRIPTION
This fixes a minor bug where, if a column has traits associated with it that specify a minimum size for that column, it becomes impossible to hide the column using the existing, built-in logic for doing so. The fix is very simple: do not enforce the minimum (or maximum) widths specified in the traits for columns that are hidden (i.e., not visible).

I made the minimum change necessary to the code, and also updated the comment. This is an extremely minor change that I do not anticipate breaking anyone's workflow.